### PR TITLE
OC-3442 [knife hp floating IP address management improvements]

### DIFF
--- a/lib/chef/knife/hp_server_create.rb
+++ b/lib/chef/knife/hp_server_create.rb
@@ -207,7 +207,7 @@ class Chef
 
       # bootstrap using private network.
       if config[:private_network]
-        bootstrap_ip_address = server.private_ip_address['addr']
+        bootstrap_ip_address = server.private_ip_address
       else
         # Use floating_ip for bootstraping
         bootstrap_ip_address = address.ip
@@ -228,7 +228,7 @@ class Chef
       sleep 30
       print(".")
 
-      print(".") until tcp_test_ssh(server.public_ip_address) {
+      print(".") until tcp_test_ssh(bootstrap_ip_address) {
         sleep @initial_sleep_delay ||= 10
         puts("done")
       }


### PR DESCRIPTION
Approach for OC-3442, existing floating-ip can be provided as cli param. If isn't provided, select an existing floating-ip address not associated to any instance. If none of existing ips are unassigned create a floating-ip.
