### PR TITLE
Add `:omit_default_port` to connection options so US-East region works again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.4.2rc1
 * Updated the README.md to reflect the new names of the regions
 * Fixed the defaulting to the US-West region
+* Added `:omit_default_port` to connection options so US-East region works again
 
 ## v0.4.0
 * Upgrade to support 13.5 HP Helion Public Cloud Services. For more information check https://docs.hpcloud.com/migration-overview/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Knife HP
 ========
 
-This is the official Opscode Knife plugin for HP Helion Public Cloud Compute. This plugin gives knife the ability to create, bootstrap and manage instances in the HP Public Cloud 13.5 and later. You may need to go to https://horizon.hpcloud.com and enable Compute under "Activate Services" for the Region you wish to use. (As of this most recent release [US-West is only supported](https://github.com/fog/fog/issues/3152), but you still have to activate the service) To properly configure your networks (include a router for external access), please refer to https://docs.hpcloud.com/hpcloudconsole.
+This is the official Opscode Knife plugin for HP Helion Public Cloud Compute. This plugin gives knife the ability to create, bootstrap and manage instances in the HP Public Cloud 13.5 and later. You may need to go to https://horizon.hpcloud.com and enable Compute under "Activate Services" for the Region you wish to use. To properly configure your networks (include a router for external access), please refer to https://docs.hpcloud.com/hpcloudconsole.
 
 If you are still using the older version of the API, you may need version 0.3.1 of this plugin, HP's migration and upgrade instructions are here: https://docs.hpcloud.com/migration-overview-reference/.
 

--- a/lib/chef/knife/hp_base.rb
+++ b/lib/chef/knife/hp_base.rb
@@ -83,7 +83,10 @@ class Chef
             :hp_access_key => locate_config_value(:hp_access_key),
             :hp_secret_key => locate_config_value(:hp_secret_key),
             :hp_tenant_id => locate_config_value(:hp_tenant_id),
-            :hp_avl_zone => region()
+            :hp_avl_zone => region(),
+            :connection_options => {
+              :omit_default_port => true
+            }
             )
                         end
       end


### PR DESCRIPTION
Reference: https://github.com/fog/fog/issues/3152#issuecomment-57482889
